### PR TITLE
fix: remove calendar event dependency

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -17,6 +17,9 @@ module.exports = {
         config: {
             usesNonExemptEncryption: false,
         },
+        // infoPlist: {
+        //     NSCalendarsUsageDescription: "This app may uses the calendar to add appointment event.",
+        // },
     },
     android: {
         adaptiveIcon: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "jest": "^29.2.1",
         "jest-expo": "~53.0.9",
         "prettier": "^3.6.2",
-        "react-native-calendar-events": "^2.2.0",
         "typescript": "~5.8.3"
       }
     },
@@ -16162,16 +16161,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-native-calendar-events": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-calendar-events/-/react-native-calendar-events-2.2.0.tgz",
-      "integrity": "sha512-tNUbhT6Ief0JM4OQzQAaz1ri0+MCcAoHptBcEXCz2g7q3A05pg62PR2Dio4F9t2fCAD7Y2+QggdY1ycAsF3Tsg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "jest": "^29.2.1",
     "jest-expo": "~53.0.9",
     "prettier": "^3.6.2",
-    "react-native-calendar-events": "^2.2.0",
     "typescript": "~5.8.3"
   },
   "private": true


### PR DESCRIPTION
- error while submitting app to app store connect: ITMS-90683: Missing purpose string in Info.plist -> NSCalendarsUsageDescription